### PR TITLE
Support CDN by using a shell worker

### DIFF
--- a/src/lzma.js
+++ b/src/lzma.js
@@ -80,6 +80,10 @@ if (typeof Worker === "undefined" || (typeof location !== "undefined" && locatio
     ///NOTE: The "this" keyword is the global context ("window" variable) if loaded via a <script> tag
     ///      or the function context if loaded as a module (e.g., in Node.js).
     this.LZMA = function (lzma_path) {
+        if (lzma_path && lzma_path.indexOf("//") >= 0) {
+            lzma_path = URL.createObjectURL(new Blob(["importScripts(" + JSON.stringify(lzma_path) + ")"]));
+        }
+
         var action_compress   = 1,
             action_decompress = 2,
             action_progress   = 3,


### PR DESCRIPTION
Fixes #50

With this changes, the following code will get worked:

```html
<script src="https://rawgit.com/umireon/LZMA-JS/support-cdn-by-shell-worker/src/lzma.js"></script>
<script>
var my_lzma = new LZMA("https://rawgit.com/umireon/LZMA-JS/support-cdn-by-shell-worker/src/lzma_worker.js")
my_lzma.compress('data', 1, function (res) {
  console.log(res)
})
</script>
```

The live example: https://jsfiddle.net/umireon/LxLxk1zf/

[Blob URLs](http://caniuse.com/#feat=bloburls) and [the Blob constructor](http://caniuse.com/#feat=blobbuilder) are used to circumvent [the same-origin policy applied to the `Worker()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker).
Supporting pretty old browsers which support [Web Workers](http://caniuse.com/#feat=webworkers) but not the Blob constructor such as Firefox 12 may require additional efforts.